### PR TITLE
Creating the proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,28 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us repair something that is currently broken
+title: "[BUG]"
+labels: 'bug'
+assignees: ''
+
+---
+<!-- Thank you for contributing. 
+These HTML commments will not render in the issue, but you can delete them once you've read them if you prefer! -->
+
+### Bug description
+<!-- Use this section to clearly and concisely describe the bug or errors. 
+We suggest using bullets (indicated by * or -) or checkboxes [ ] (filled checkbox [x]) here -->
+
+- [ ] ITEM1
+- [ ] ITEM2
+
+#### Proposed changes
+<!-- What changes your propose to fix this bug. You can leave this out if you don't have a solution already. 
+We suggest using bullets (indicated by * or -) or checkboxes [ ] (filled checkbox [x]) here -->
+
+- [ ] ITEM1
+- [ ] ITEM2
+
+#### Other comment
+
+- [ ] ITEM1

--- a/.github/ISSUE_TEMPLATE/NEW_PROPOSAL.md
+++ b/.github/ISSUE_TEMPLATE/NEW_PROPOSAL.md
@@ -41,7 +41,7 @@ Please complete the following sections when you open a new proposal issue.
 
 * Country of residence and/or compatible Time Zones (provide options): WRITE HERE
 
-* Would you like to present this multiple times in other time zones: WRITE HERE 
+* Would you like to present this multiple times, in other time zones: WRITE HERE 
 <!-- please suggest suitable time zones -->
 
 * Would you like to volunteer to be listed as a wrangler/host for your time zone 

--- a/.github/ISSUE_TEMPLATE/NEW_PROPOSAL.md
+++ b/.github/ISSUE_TEMPLATE/NEW_PROPOSAL.md
@@ -1,0 +1,50 @@
+
+---
+name: "\U0001F4D6 New Proposal"
+about: Template for creating a new proposal
+title:
+labels: 
+assignees: ''
+
+---
+<!--
+Please complete the following sections when you open a new proposal issue.
+-->
+
+## Title of the session: WRITE HERE
+<!-- Please provide a short title of your proposal capturing what your target audience would expect in this session.
+-->
+
+### Session details
+
+* Session type: WRITE HERE 
+<!-- Choose from these options: Breakout discussion, skill-up, social event, lightening talk, informal meetup, panel, pub quiz on specific topic, or other -->
+
+* Keywords: WRITE HERE 
+<!--Please provide 3-5 keywords to help your expected target audience to decide the relevance of this session-->
+
+* Permission to record this session: WRITE HERE 
+<!-- Please asnwer in 'Yes' or 'No', Since this session will be possibly taking place in a time zone that is not compatible for everyone, we would liek to record the presentation/introduction and conclusion/final wrap up part of your session through Zoom recording option.-->
+
+### Abstract
+<!-- Please provide a short  -->
+
+* WRITE HERE
+
+### Personal details
+
+* Name or pseudoname of the session lead: WRITE HERE
+
+* Co-leads' names (we recommend involving 2 helpers/co-leads): WRITE HERE
+
+* Email or other ways to contact the session leads/co-leads: WRITE HERE
+
+* Country of residence and/or compatible Time Zones (provide options): WRITE HERE
+
+* Would you like to present this multiple times in other time zones: WRITE HERE 
+<!-- please suggest suitable time zones -->
+
+* Would you like to volunteer to be listed as a wrangler/host for your time zone 
+<!-- Respond in "Yes", "No", "Contact me with more details". Wraglers/hosts will coordinate 1-2 other sessions by coordinating with their session leads before their session to make sure that their slides or other required materials work. During the session they will introduce the session lead and other facilitators, share the link of the notes with the attendees, introduce the Code of Conduct and participation guideline, and with the permission of the attendees record the presentation parts of the session.-->
+
+* Other comments: WRITE HERE

--- a/.github/ISSUE_TEMPLATE/NEW_PROPOSAL.md
+++ b/.github/ISSUE_TEMPLATE/NEW_PROPOSAL.md
@@ -18,7 +18,7 @@ Please complete the following sections when you open a new proposal issue.
 ### Session details
 
 * Session type: WRITE HERE 
-<!-- Choose from these options: Breakout discussion, skill-up, social event, lightening talk, informal meetup, panel, pub quiz on specific topic, or other -->
+<!-- Choose from these options: Breakout discussion, skill-up, social event, lightning talk, informal meetup, panel, or other -->
 
 * Keywords: WRITE HERE 
 <!--Please provide 3-5 keywords to help your expected target audience to decide the relevance of this session-->

--- a/.github/ISSUE_TEMPLATE/NEW_PROPOSAL.md
+++ b/.github/ISSUE_TEMPLATE/NEW_PROPOSAL.md
@@ -27,7 +27,7 @@ Please complete the following sections when you open a new proposal issue.
 <!-- Please asnwer in 'Yes' or 'No', Since this session will be possibly taking place in a time zone that is not compatible for everyone, we would liek to record the presentation/introduction and conclusion/final wrap up part of your session through Zoom recording option.-->
 
 ### Abstract
-<!-- Please provide a short  -->
+<!-- Please provide a short abstract of no more than 250 words - give some background, format of the session, learning/expected outcome, target audience, and possible future directions."-->
 
 * WRITE HERE
 

--- a/.github/ISSUE_TEMPLATE/NEW_PROPOSAL.md
+++ b/.github/ISSUE_TEMPLATE/NEW_PROPOSAL.md
@@ -18,7 +18,7 @@ Please complete the following sections when you open a new proposal issue.
 ### Session details
 
 * Session type: WRITE HERE 
-<!-- Choose from these options: Breakout discussion, skill-up, social event, lightning talk, informal meetup, panel, or other -->
+<!-- Choose from these options: Breakout discussion, skill-up, social event, lightning talk, informal meetup, panel, lesson or resource development sprint or other -->
 
 * Keywords: WRITE HERE 
 <!--Please provide 3-5 keywords to help your expected target audience to decide the relevance of this session-->


### PR DESCRIPTION
## Summary

This issue proposes a template for new proposals. It is possible to add more issues to reflect different types.

## Who can help?

@mkuzak can you please review this?
@serahrono if you can make a few labels for proposal type, we can tag issues by session type.

## Other comment

We also have a wrangler/host sign up sheet ready, not sure if we need to add that in the issue, but should be added in the README file: https://docs.google.com/spreadsheets/d/13ONzgvIilIy1T_9ad_CDFmSGR_VjqEXTKyz1fit9iXA/edit?usp=sharing